### PR TITLE
Do not serialize Manifest properties with a `null` value

### DIFF
--- a/Firely.Fhir.Packages.Tests/ManifestSerializationTest.cs
+++ b/Firely.Fhir.Packages.Tests/ManifestSerializationTest.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System.IO;
+
+namespace Firely.Fhir.Packages.Tests
+{
+    [TestClass]
+    public class ManifestSerializationTest
+    {
+        [TestMethod]
+        public void DoesNotWriteNulls()
+        {
+            PackageManifest manif = ManifestFile.Create("a-b-c", 4);
+
+            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+
+            FolderProject proj = new FolderProject(tempDir);
+            proj.WriteManifest(manif);
+
+            var json = File.ReadAllText(Path.Combine(tempDir, PackageConsts.Manifest));
+            var parsedJson = JObject.Parse(json);
+
+            // we should not find an `'author' : null` property
+            Assert.IsFalse(parsedJson.ContainsKey("author"));
+        }
+    }
+}

--- a/Firely.Fhir.Packages/Core/Parser.cs
+++ b/Firely.Fhir.Packages/Core/Parser.cs
@@ -31,7 +31,8 @@ namespace Firely.Fhir.Packages
 
         public static string WriteManifest(PackageManifest manifest)
         {
-            return JsonConvert.SerializeObject(manifest, Formatting.Indented)+"\n";
+            return JsonConvert.SerializeObject(manifest, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore } )+"\n";
+            //return JsonConvert.SerializeObject(manifest, Formatting.Indented )+"\n";
         }
 
         //public static string JsonMerge(object thing, string contents)


### PR DESCRIPTION
The project.json file produced by WriteManifest() would contain fragments like `'author': null`.  It may be acceptable, but looks nasty. I changed the code to omit such properties.
