### PR TITLE
fix: folders with spaces and uniform fhir version handling

### DIFF
--- a/Firely.Fhir.Packages/Disk/CanonicalIndexer.cs
+++ b/Firely.Fhir.Packages/Disk/CanonicalIndexer.cs
@@ -31,6 +31,8 @@ namespace Firely.Fhir.Packages
             try
             {
                 var node = ElementNavigation.ParseToSourceNode(filepath);
+                if (node is null) return null;
+
                 string? canonical = node.GetString("url"); // node.Children("url").FirstOrDefault()?.Text;
 
                 return new ResourceMetadata
@@ -53,6 +55,8 @@ namespace Firely.Fhir.Packages
 
         public static string GetString(this ISourceNode node, string expression)
         {
+            if (node is null) return null;
+
             var parts = expression.Split('.');
             
             foreach (var part in parts)
@@ -77,11 +81,12 @@ namespace Firely.Fhir.Packages
 
             Uri baseUri = new Uri(relativeTo);
             Uri fullUri = new Uri(path);
-
+            
             Uri relativeUri = baseUri.MakeRelativeUri(fullUri);
 
             // Uri's use forward slashes so convert back to backward slashes
-            return relativeUri.ToString();
+            var result = Uri.UnescapeDataString(relativeUri.ToString());
+            return result;
 
         }
     }

--- a/Firely.Fhir.Packages/Disk/FolderProject.cs
+++ b/Firely.Fhir.Packages/Disk/FolderProject.cs
@@ -46,7 +46,8 @@ namespace Firely.Fhir.Packages
         /// <returns></returns>
         public Task<PackageManifest> ReadManifest()
         {
-            return Task.FromResult(ManifestFile.ReadFromFolder(Folder));
+            var manifest = ManifestFile.ReadFromFolder(Folder);
+            return Task.FromResult(manifest); ;
         }
 
         public Task WriteClosure(PackageClosure closure)

--- a/Firely.Fhir.Packages/Disk/ManifestFile.cs
+++ b/Firely.Fhir.Packages/Disk/ManifestFile.cs
@@ -75,7 +75,8 @@ namespace Firely.Fhir.Packages
         public static PackageManifest ReadFromFolder(string folder)
         {
             var path = Path.Combine(folder, PackageConsts.Manifest);
-            return Read(path);
+            var manifest = Read(path);
+            return manifest;
         }
 
         /// <summary>
@@ -86,16 +87,18 @@ namespace Firely.Fhir.Packages
         /// <returns></returns>
         public static PackageManifest Create(string name, string fhirVersion)
         {
-            var version = FhirVersions.Parse(fhirVersion);
+            var release = FhirVersions.Parse(fhirVersion);
+            var version = FhirVersions.FhirVersionFromRelease(release);
 
-            return new PackageManifest
+            var manifest = new PackageManifest
             {
                 Name = name,
                 Description = "Put a description here",
                 Version = "0.1.0",
-                FhirVersions = new List<string> { FhirVersions.FhirVersionFromRelease(version) },
                 Dependencies = new Dictionary<string, string>()
             };
+            manifest.SetFhirVersion(version);
+            return manifest;
         }
 
         ///// <summary>

--- a/Firely.Fhir.Packages/Extensions/IPackageCacheExtensions.cs
+++ b/Firely.Fhir.Packages/Extensions/IPackageCacheExtensions.cs
@@ -48,7 +48,7 @@ namespace Firely.Fhir.Packages
         public static async Task<string> ReadPackageFhirVersion(this IPackageCache cache, PackageReference reference)
         {
             var m = await cache.ReadManifest(reference);
-            var fhirVersion = m.FhirVersions.FirstOrDefault();
+            var fhirVersion = m.GetFhirVersion();
             return fhirVersion;
         } 
 

--- a/Firely.Fhir.Packages/Extensions/PackageScopeExtensions.cs
+++ b/Firely.Fhir.Packages/Extensions/PackageScopeExtensions.cs
@@ -91,8 +91,7 @@ namespace Firely.Fhir.Packages
             var reference = await scope.CacheInstall(dependency);
             if (reference.NotFound) throw new Exception($"Package '{dependency}' was not found.");
 
-            var manifest = scope.Project.ReadManifest();
-            if (manifest is null)
+            if (!await scope.Project.HasManifest())
             {
                 var fhirVersion = await scope.Cache.ReadPackageFhirVersion(reference);
                 await scope.EnsureManifest("project", fhirVersion);

--- a/Firely.Fhir.Packages/Models/JsonModels.cs
+++ b/Firely.Fhir.Packages/Models/JsonModels.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Firely.Fhir.Packages
 {
@@ -239,7 +240,6 @@ namespace Firely.Fhir.Packages
         public string FhirVersion;
     }
 
-
     public static class JsonModelExtensions
     {
         public static PackageReference GetPackageReference(this PackageManifest manifest)
@@ -300,6 +300,20 @@ namespace Firely.Fhir.Packages
                 }
             }
             return false;
+        }
+
+        public static string GetFhirVersion(this PackageManifest manifest)
+        {
+            string version =
+                manifest.FhirVersions?.FirstOrDefault()
+                ?? manifest.FhirVersionList?.FirstOrDefault();
+
+            return version;
+        }
+
+        public static void SetFhirVersion(this PackageManifest manifest, string version)
+        {
+            manifest.FhirVersions = new List<string> { version };
         }
     }
 }


### PR DESCRIPTION
- One way of getting/setting the Fhir version from a manifest.
- And a fix for handling paths with spaces.
