### PR TITLE
Issue-38

### DIFF
--- a/Firely.Fhir.Packages.Tests/Packaging.cs
+++ b/Firely.Fhir.Packages.Tests/Packaging.cs
@@ -1,8 +1,10 @@
 ﻿using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Packages.Tests
 {
@@ -46,6 +48,66 @@ namespace Firely.Fhir.Packages.Tests
             package.Should().Contain(e => e.FilePath == @"package\other\.index.json");
 
 
+        }
+
+        [TestMethod]
+        [DataRow(true, 0)]
+        [DataRow(true, 1)]
+        [DataRow(true, 1)]
+        [DataRow(false, 0)]
+        [DataRow(false, 1)]
+        [DataRow(false, 1)]
+        public async Task HandleInvalidPackagesOnRestore(bool includeValidPackage, int invalidPackageCount)
+        {
+            // Arrange
+            const string packageName = "MyInvalidPackage";
+            const string packageRange = "invalid";
+
+            var dependencies = new List<string>();
+
+            if (includeValidPackage)
+                dependencies.Add(IndexGenerationTest.HL7_CORE_PACKAGE_R4);
+
+            for (int i = 0; i < invalidPackageCount; i++)
+                dependencies.Add($"{packageName}{i+1}@{i+1}.{packageRange}");
+
+            var fixtureDirectory = TestHelper.InitializeTemporary("integration-test", dependencies.ToArray()).Result;
+
+            // Act
+            try
+            {
+                // TestHelper.Open calls restore on package context
+                await TestHelper.Open(fixtureDirectory, _ => { });
+            }
+            catch (AggregateException aex)
+            {
+                if (invalidPackageCount > 0)
+                {
+                    // Assert
+                    aex.InnerExceptions.Should().HaveCount(invalidPackageCount);
+                    aex.Message.Should().Be($"One or more errors occurred. (Invalid version string: \"1.{packageRange}\")");
+
+                    for (int i = 0; i < invalidPackageCount; i++)
+                    {
+                        aex.InnerExceptions[i].Should().BeOfType<PackageRestoreException>();
+
+                        var prex = (PackageRestoreException)aex.InnerExceptions[i];
+
+                        prex.PackageDependencies.Should().HaveCount(1);
+
+                        var dependency = prex.PackageDependencies.Single();
+
+                        dependency.Name.Should().Be($"{packageName}{i + 1}");
+
+                        prex.Message.Should().Be($"Invalid version string: \"{i + 1}.{packageRange}\"");
+                    }
+
+                    return;
+                }
+            }
+
+            if (invalidPackageCount > 0)
+                Assert.Fail("Expected AggregateException to be thrown");
         }
 
         private static FileEntry createFileEntry(string content, string path) => new(path, Encoding.ASCII.GetBytes(content));

--- a/Firely.Fhir.Packages/Core/PackageRestoreException.cs
+++ b/Firely.Fhir.Packages/Core/PackageRestoreException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Firely.Fhir.Packages
+{
+    /// <summary>
+    /// The exception that is thrown when a package dependency could not be restored. 
+    /// </summary>
+    public class PackageRestoreException : Exception
+    {
+        /// <summary>
+        /// Package dependency chain for this exception.
+        /// The exception is linked to the last dependency in the list.
+        /// The first dependency in the list represents the root of the dependency chain.
+        /// </summary>
+        public IReadOnlyCollection<PackageDependency> PackageDependencies { get; }
+
+        internal PackageRestoreException(IEnumerable<PackageDependency> dependencies, Exception exception) : base(exception.Message)
+        {
+            PackageDependencies = new List<PackageDependency>(dependencies);
+        }
+    }
+}

--- a/Firely.Fhir.Packages/Core/PackageRestorer.cs
+++ b/Firely.Fhir.Packages/Core/PackageRestorer.cs
@@ -10,6 +10,8 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Firely.Fhir.Packages
@@ -33,14 +35,25 @@ namespace Firely.Fhir.Packages
         /// Restore packages dependencies
         /// </summary>
         /// <returns>Package closure</returns>
-        /// <exception cref="Exception">Exeption thrown when a package doesn't have a manifest file</exception>
+        /// <exception cref="AggregateException">AggregateException thrown when a package doesn't have a manifest file and/or a package is invalid.
+        /// The inner exceptions can be examined for more detailed information. The inner exceptions can contain exceptions of type
+        /// <see cref="PackageRestoreException"/> that contain additional information on the erroneous package.
+        /// </exception>
         public async Task<PackageClosure> Restore()
         {
             _closure = new();
             var manifest = await _context.Project.ReadManifest().ConfigureAwait(false);
-            if (manifest is null) throw new Exception("This context does not have a package manifest (package.json)");
 
-            await restoreManifest(manifest).ConfigureAwait(false);
+            if (manifest is null) 
+                throw new Exception("This context does not have a package manifest (package.json)");
+
+            var errors = new List<Exception>();
+
+            await restoreManifest(manifest, errors, new Stack<PackageDependency>()).ConfigureAwait(false);
+
+            if (errors.Any())
+                throw new AggregateException(errors);
+
             await SaveClosure().ConfigureAwait(false);
             return _closure;
         }
@@ -54,34 +67,44 @@ namespace Firely.Fhir.Packages
             await _context.Project.WriteClosure(_closure).ConfigureAwait(false);
         }
 
-        private async Task restoreManifest(PackageManifest manifest)
+        private async Task restoreManifest(PackageManifest manifest, List<Exception> errors, Stack<PackageDependency> dependencyChain)
         {
             foreach (PackageDependency dependency in manifest.GetDependencies())
             {
-                await restoreDependency(dependency).ConfigureAwait(false);
+                dependencyChain.Push(dependency);
+                await restoreDependency(dependency, errors, dependencyChain).ConfigureAwait(false);
+                dependencyChain.Pop();
             }
         }
 
-        private async Task restoreDependency(PackageDependency dependency)
+        private async Task restoreDependency(PackageDependency dependency, List<Exception> errors, Stack<PackageDependency> dependencyChain)
         {
-            var reference = await _context.CacheInstall(dependency).ConfigureAwait(false);
-            if (reference.Found)
+            try
             {
-                _closure.Add(reference);
-                await restoreReference(reference).ConfigureAwait(false);
+                var reference = await _context.CacheInstall(dependency).ConfigureAwait(false);
+
+                if (reference.Found)
+                {
+                    _closure.Add(reference);
+                    await restoreReference(reference, errors, dependencyChain).ConfigureAwait(false);
+                }
+                else
+                {
+                    _closure.AddMissing(dependency);
+                }
             }
-            else
+            catch (Exception e)
             {
-                _closure.AddMissing(dependency);
+                errors.Add(new PackageRestoreException(dependencyChain.Reverse(), e));
             }
         }
 
-        private async Task restoreReference(PackageReference reference)
+        private async Task restoreReference(PackageReference reference, List<Exception> errors, Stack<PackageDependency> dependencyChain)
         {
             var manifest = await _context.Cache.ReadManifest(reference);
             if (manifest is not null)
             {
-                await restoreManifest(manifest).ConfigureAwait(false);
+                await restoreManifest(manifest, errors, dependencyChain).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
PackageRestorer restore now accumulates errors into an AggregateException and includes package information when available in a PackageRestoreException. Added unit test HandleInvalidPackagesOnRestore.