### PR TITLE
Devops: Move the Azure pipeline to SDK project in Azure Devops

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -10,6 +10,7 @@ resources:
 
 variables:
   - group: CodeSigning
+  - group: APIKeys
   - template: variables.yml  
 
 pool: 

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -7,4 +7,4 @@ variables:
   vmImage: 'windows-latest'
   DOTNET_CORE_SDK: '6.0.x'
   GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey) # key is set in UI of Azure Devops
-  NUGET_APIKEY: $(NuGetAPIKey)
+  NUGET_APIKEY: $(NuGetFhirPackagesAPIKey)

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -6,5 +6,5 @@ variables:
   buildConfiguration: 'Release'
   vmImage: 'windows-latest'
   DOTNET_CORE_SDK: '6.0.x'
-  GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey) # key is set in UI of Azure Devops
-  NUGET_APIKEY: $(NuGetFhirPackagesAPIKey)
+  GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey) # key is set in variable group APIKeys
+  NUGET_APIKEY: $(NuGetFhirPackagesAPIKey) # key is set in variable group APIKeys


### PR DESCRIPTION
Move the Azure pipeline for this repo to the SDK project in Azure Devops. This makes the maintenance a bit more easier: one set of service connections for example...