### PR TITLE
Leave examples in the example folder when reorganizing a package

### DIFF
--- a/Firely.Fhir.Packages.Tests/Packaging.cs
+++ b/Firely.Fhir.Packages.Tests/Packaging.cs
@@ -29,7 +29,22 @@ namespace Firely.Fhir.Packages.Tests
 
             Assert.AreEqual(@"package\patient.xml", file.FilePath);
 
+            //example files already in the correct structure should stay in the example folder
+            file =
+                new FileEntry(@"package\examples\example-patient.json", System.Array.Empty<byte>())
+                .OrganizeToPackageStructure();
+
+            Assert.AreEqual(@"package\examples\example-patient.json", file.FilePath);
+
+            //example files already in the correct structure should stay in the example folder, but subfolders should be flattened
+            file =
+                new FileEntry(@"package\examples\random\example-patient.json", System.Array.Empty<byte>())
+                .OrganizeToPackageStructure();
+
+            Assert.AreEqual(@"package\examples\example-patient.json", file.FilePath);
+
         }
+
 
         [TestMethod]
         public void TestGeneratingIndexFiles()

--- a/Firely.Fhir.Packages/Constants/PackageConsts.cs
+++ b/Firely.Fhir.Packages/Constants/PackageConsts.cs
@@ -9,6 +9,8 @@
 
 #nullable enable
 
+using System.IO;
+
 namespace Firely.Fhir.Packages
 {
     public static class PackageFileNames
@@ -18,8 +20,10 @@ namespace Firely.Fhir.Packages
         public const string CANONICALINDEXFILE = ".firely.index.json";
         public const string INDEXJSONFILE = ".index.json";
         public const string PACKAGEFOLDER = "package";
+        public const string EXAMPLEFOLDER = "examples";
+        public static string EXAMPLEFOLDERPATH => PACKAGEFOLDER + Path.DirectorySeparatorChar + EXAMPLEFOLDER;
 
-        public static readonly string[] ALL_PACKAGE_FILENAMES = { MANIFEST, LOCKFILE, CANONICALINDEXFILE, INDEXJSONFILE, PACKAGEFOLDER };
+        public static readonly string[] ALL_PACKAGE_FILENAMES = { MANIFEST, LOCKFILE, CANONICALINDEXFILE, INDEXJSONFILE };
 
     }
 

--- a/Firely.Fhir.Packages/Tar/FileEntries.cs
+++ b/Firely.Fhir.Packages/Tar/FileEntries.cs
@@ -141,10 +141,12 @@ namespace Firely.Fhir.Packages
         {
             if (file.match(PackageFileNames.MANIFEST))
                 return file.ChangeFolder(PackageFileNames.PACKAGEFOLDER);
-
             else if (file.hasExtension(".xml", ".json"))
-                return file.ChangeFolder(PackageFileNames.PACKAGEFOLDER);
-
+            {
+                return file.FilePath.StartsWith(PackageFileNames.EXAMPLEFOLDERPATH)
+                    ? file.ChangeFolder(PackageFileNames.EXAMPLEFOLDERPATH)
+                    : file.ChangeFolder(PackageFileNames.PACKAGEFOLDER);
+            }
             else
                 return file.ChangeFolder(FOLDER_OTHER);
         }


### PR DESCRIPTION
fixes #80