### PR TITLE
Enable trusted signing in Azure Pipelines

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -38,8 +38,10 @@ stages:
       packageArtifacts: true
       signingKeyFileName: 'FirelyPackages.snk' 
       filesForSigning: '$(Build.SourcesDirectory)\Firely.Fhir.Packages\bin\Release\*\Firely.Fhir.Packages.dll'
-      codeSignerCertificate: $(FirelyCodeSignerCertificate)
-      codeSignerPassword: $(CodeSigningPassword)
+      certificateProfileName: 'FirelyCodeSigning'
+      trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
+      trustedSigningAccountName: 'FirelyCodeSigning'
+      azureServiceConnection: 'AzureTrustedSigningPrincipal'
       pool: 
         vmImage: $(vmImage)
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -41,7 +41,7 @@ stages:
       certificateProfileName: 'FirelyCodeSigning'
       trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
       trustedSigningAccountName: 'FirelyCodeSigning'
-      azureServiceConnection: 'AzureTrustedSigningPrincipal'
+      azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
       pool: 
         vmImage: $(vmImage)
 


### PR DESCRIPTION
This pull request updates the Azure Pipelines configuration to modernize and improve the code signing process. The main change is a shift from using direct certificate and password variables to leveraging Azure's Trusted Signing infrastructure for enhanced security and manageability.

**Build pipeline improvements:**

* Switched from using `codeSignerCertificate` and `codeSignerPassword` to Azure Trusted Signing by adding `certificateProfileName`, `trustedSigningAccountEndpoint`, `trustedSigningAccountName`, and `azureServiceConnectionForSigning` parameters in the pipeline configuration (`build/azure-pipelines.yml`).