### PR TITLE
Release 5.0.1

### DIFF
--- a/Firely.Fhir.Packages.props
+++ b/Firely.Fhir.Packages.props
@@ -5,13 +5,13 @@
 		<TargetFrameworks>net8.0;netstandard2.1;</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <FhirNetSdkVersion>6.0.1</FhirNetSdkVersion>
+    <FhirNetSdkVersion>6.0.2</FhirNetSdkVersion>
 	</PropertyGroup>
 
     <!-- Solution-wide properties for NuGet packaging -->
     <PropertyGroup>
         <LangVersion>12.0</LangVersion>
-        <VersionPrefix>5.0.0</VersionPrefix>
+        <VersionPrefix>5.0.1</VersionPrefix>
         <VersionSuffix></VersionSuffix>
         <Authors>Firely</Authors>
         <Company>Firely (https://fire.ly)</Company>


### PR DESCRIPTION
This pull request updates project-wide package and version settings to ensure compatibility with the latest dependencies and to increment the release version.

Dependency and version updates:

* Updated the `FhirNetSdkVersion` property from `6.0.1` to `6.0.2` in `Firely.Fhir.Packages.props` to use the latest version of the FHIR .NET SDK.
* Incremented the `VersionPrefix` property from `5.0.0` to `5.0.1` in `Firely.Fhir.Packages.props` for a new release version.