### PR TITLE
Only sign NuGet packages on v* tag releases

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -38,10 +38,11 @@ stages:
       packageArtifacts: true
       signingKeyFileName: 'FirelyPackages.snk' 
       filesForSigning: '$(Build.SourcesDirectory)\Firely.Fhir.Packages\bin\Release\*\Firely.Fhir.Packages.dll'
-      certificateProfileName: 'FirelyCodeSigning'
-      trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
-      trustedSigningAccountName: 'FirelyCodeSigning'
-      azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
+      ${{ if startswith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
+        certificateProfileName: 'FirelyCodeSigning'
+        trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
+        trustedSigningAccountName: 'FirelyCodeSigning'
+        azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
       pool: 
         vmImage: $(vmImage)
 


### PR DESCRIPTION
Signing with Azure Trusted Signing is only needed when publishing to NuGet. This change ensures the signing step is skipped on regular branch builds and only runs when triggered by a `v*` release tag.