### PR TITLE
Skip build stages when only docs change (DEVOPS-715)

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -25,7 +25,14 @@ trigger:
     - refs/tags/v*
 
 stages:
+- template: check-skip-stage.yml@templates
+  parameters:
+    ignorePatterns:
+      - '.+\.md$'
+
 - stage: build
+  dependsOn: checkSkipStage
+  condition: and(succeeded(), ne(dependencies.checkSkipStage.outputs['checkChanges.evaluateIgnorePatterns.skip'], 'true'))
   jobs:
   - template: build.yml@templates  # Template reference
     parameters:


### PR DESCRIPTION
Fixes: https://firely.atlassian.net/browse/DEVOPS-715

## Summary

Adds the shared `check-skip-stage.yml@templates` gate so docs-only commits no longer trigger the full build/deploy chain. Closes the final subtask of DEVOPS-706 (DEVOPS-715: Implement in packages).

Same pattern just rolled out across:
- Vonk (FirelyTeam/Vonk#3075)
- Firely.Auth (FirelyTeam/Firely.Auth#1889)
- firely-net-sdk (FirelyTeam/firely-net-sdk#3496)
- Firely.Validator (FirelyTeam/Firely.Validator#27)
- firely-car (FirelyTeam/firely-car#388)
- firely-cql-sdk (FirelyTeam/firely-cql-sdk#1246)

Ignore pattern: `.+\.md$` — this repo has no `docs/` folder; markdown files are `readme.md`, `contributors.md` and `Firely.Fhir.Packages/ReleaseNotes.md`.

## How it works

A new `checkSkipStage` runs first and sets a `skip` output variable. The `build` stage is gated on `checkChanges.evaluateIgnorePatterns.skip != 'true'`. Downstream stages (`deployToGitHub`, `deployToNuget`) cascade-skip via their existing `dependsOn` chains plus default `succeeded()` condition.

## Test plan

- [ ] Verify a docs-only commit on this branch correctly skips the full pipeline.
- [ ] Verify a code commit on this branch runs the full pipeline as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)